### PR TITLE
Add convict config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,21 @@
+var convict = require('convict');
+
+var config = convict({
+  ip: {
+    doc: "The http server will bind to this IP address",
+    format: "ipaddress",
+    default: "127.0.0.1",
+    env: "IMPACT_IP",
+    arg: "ip"
+  },
+  port: {
+    doc: "The http server will listen on this port",
+    format: "port",
+    default: 3132,
+    env: "IMPACT_PORT",
+    arg: "port"
+  }
+});
+
+config.validate({strict: true});
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "webpack": "~1.12.14"
   },
   "dependencies": {
+    "convict": "~1.1.2",
     "rethinkdb": "~2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/HackerHappyHour/impact#readme",
   "devDependencies": {
+    "chai": "~3.5.0",
     "eslint": "~2.3.0",
     "mocha": "~2.4.5",
     "webpack": "~1.12.14"

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,3 @@
+var chai = require("chai");
+
+global.expect = chai.expect;

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -1,0 +1,13 @@
+var config = require("../lib/config.js");
+
+describe("config", function(){
+  context("has default values", function(){
+    it ("includes an ip", function(){
+      expect(config.get("ip")).to.eql("127.0.0.1");
+    });
+
+    it("includes a port", function(){
+      expect(config.get("port")).to.eql(3132);
+    });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --require ./test/common.js
---runner spec
+--reporter spec


### PR DESCRIPTION
Adds a simple convict-based config setup. Obviously we can add more options for config files and such later on, once we figure out how we're going to want to switch DB urls, etc.

<!---
@huboard:{"order":2.5,"milestone_order":17,"custom_state":""}
-->
